### PR TITLE
Relax version constraints for modules

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,11 @@
 terraform {
+  required_version = ">= 0.15"
+
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">= 3, < 5"
+      version               = ">= 3"
       configuration_aliases = [aws.global, aws.regional]
     }
   }
-  required_version = ">= 0.15"
 }


### PR DESCRIPTION
Remove upper boundary as version upgrades need to be tested when applying the root modules anyway.