### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,5 @@ module "acm" {
     "example.com"     = "XYZXYZXYZXYZXYZ"
     "www.example.com" = "YZXYZXYZXYZXYZX"
   }
-
-  tags = {
-    app  = "some-service"
-    env  = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -23,7 +23,7 @@ module "acm" {
     "www.example.com" = "YZXYZXYZXYZXYZX"
   }
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "production"
   }

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -9,7 +9,7 @@ provider "aws" {
 }
 
 module "acm" {
-  source  = "./.."
+  source = "./.."
 
   providers = {
     aws.global   = aws.global
@@ -24,7 +24,7 @@ module "acm" {
   }
 
   tags = {
-    app  = "some-service"
-    env  = "production"
+    app = "some-service"
+    env = "production"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "aws_acm_certificate" "global" {
   subject_alternative_names = setsubtract(keys(var.domain_names_to_zone_ids), [var.primary_domain_name])
   validation_method         = "DNS"
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.global_acm_certificate_tags)
 
   lifecycle {
     create_before_destroy = true
@@ -19,7 +19,7 @@ resource "aws_acm_certificate" "regional" {
   subject_alternative_names = setsubtract(keys(var.domain_names_to_zone_ids), [var.primary_domain_name])
   validation_method         = "DNS"
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.regional_acm_certificate_tags)
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,42 @@
-variable "primary_domain_name" {
-  description = "A domain name for which the certificate should be issued"
-  type        = string
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
 }
 
 variable "domain_names_to_zone_ids" {
-  description = "Map of domain names (incl. `var.primary_domain_name`) to Route53 hosted zone IDs"
-  type        = map(string)
+  type = map(string)
+
+  description = <<EOS
+Map of domain names (incl. `var.primary_domain_name`) to Route53 hosted zone IDs.
+EOS
 }
 
-variable "tags" {
-  description = "A mapping of tags to assign to the resource"
-  type        = map(string)
-  default     = {}
+variable "global_acm_certificate_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the global ACM certificate. Overrides tags in `var.default_tags`.
+EOS
+}
+
+variable "primary_domain_name" {
+  type = string
+
+  description = <<EOS
+A domain name for which the certificate should be issued.
+EOS
+}
+
+variable "regional_acm_certificate_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the regional ACM certificate. Overrides tags in `var.default_tags`.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.